### PR TITLE
DELETE endpoint at /users

### DIFF
--- a/raw_sql/api.py
+++ b/raw_sql/api.py
@@ -3,7 +3,7 @@ import json
 from fastapi import APIRouter, Response
 from pydantic import ValidationError
 
-from .db import fetch_all_users, create_user_in_db, update_user_in_db, fetch_user
+from .db import fetch_all_users, create_user_in_db, update_user_in_db, fetch_user, delete_user_from_db
 from models.user import UserData
 
 users_router = APIRouter(prefix="/v1/users")
@@ -48,3 +48,19 @@ async def partial_update_user(user_id: int, user_data: dict):
         )
 
     return await update_user_in_db(user_id, user)
+
+
+@users_router.delete("/{user_id}")
+async def delete_user(user_id: int):
+    success = await delete_user_from_db(user_id)
+    if not success:
+        return Response(
+            json.dumps({"error": "User not found"}),
+            status_code=404,
+            headers={"Content-Type": "application/json"}
+        )
+    return Response(
+        json.dumps({"message": "User deleted successfully"}),
+        status_code=200,
+        headers={"Content-Type": "application/json"}
+    )

--- a/raw_sql/db.py
+++ b/raw_sql/db.py
@@ -2,9 +2,10 @@ import aiomysql
 
 from models.user import User, UserData
 
-connect = lambda : aiomysql.connect(
+connect = lambda: aiomysql.connect(
     host="localhost",
     user="root",
+    password="root",
     db="fastapi",
 )
 
@@ -57,7 +58,8 @@ async def update_user_in_db(user_id, user_data: UserData) -> User:
         async with connection.cursor() as cursor:
             await cursor.execute(
                 "UPDATE user SET first_name=%s, last_name=%s, phone_number=%s, email=%s, password=%s WHERE id=%s",
-                (user_data.first_name, user_data.last_name, user_data.phone_number, user_data.email, user_data.password, user_id)
+                (user_data.first_name, user_data.last_name, user_data.phone_number, user_data.email, user_data.password,
+                 user_id)
             )
             await connection.commit()
 
@@ -88,3 +90,16 @@ async def fetch_user(user_id: int) -> User | None:
                 email=record[4],
                 password=record[5],
             )
+
+
+async def delete_user_from_db(user_id: int) -> bool:
+    async with connect() as connection:
+        async with connection.cursor() as cursor:
+            await cursor.execute("SELECT 1 FROM user WHERE id=%s", (user_id,))
+            exists = await cursor.fetchone()
+            if not exists:
+                return False
+
+            await cursor.execute("DELETE FROM user WHERE id=%s", (user_id,))
+            await connection.commit()
+            return True


### PR DESCRIPTION
Extend the FastAPI Application:

Implement a DELETE endpoint at /users:
The endpoint should delete a user by their unique identifier.
Implement any relevant checks to ensure valid user deletion (e.g., user ID exists in the database).
Return appropriate success or error messages based on the operation's outcome.